### PR TITLE
`assemblyMergeStrategy` を定義し、`module-info.class` の重複を回避する

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,12 @@ lazy val root = (project in file("."))
       "org.http4s" %% "http4s-ember-client" % http4sVersion % Test
     ),
     assembly / mainClass := Some("Main"),
+    ThisBuild / assemblyMergeStrategy := {
+      case "module-info.class" => MergeStrategy.discard
+      case x =>
+        val oldStrategy = (assembly / assemblyMergeStrategy).value
+        oldStrategy(x)
+    },
     Docker / packageName := "sample-webapp",
     Docker / version := "2.0.0",
     dockerBaseImage := "eclipse-temurin:latest",


### PR DESCRIPTION
[logback-classic を1.4.0に更新した](https://github.com/yokra9/scalatra-example/pull/7)ことにより、`sbt assembly` による FAT JAR 生成時に `module-info.class` の重複が発生した：

```log
[error] 1 error was encountered during merge
[error] java.lang.RuntimeException: deduplicate: different file contents found in the following:
[error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.4.0/logback-classic-1.4.0.jar:module-info.class
[error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-core/1.4.0/logback-core-1.4.0.jar:module-info.class
[error]         at sbtassembly.Assembly$.applyStrategies(Assembly.scala:205)
[error]         at sbtassembly.Assembly$.x$1$lzycompute$1(Assembly.scala:49)
[error]         at sbtassembly.Assembly$.x$1$1(Assembly.scala:47)
[error]         at sbtassembly.Assembly$.stratMapping$lzycompute$1(Assembly.scala:47)
[error]         at sbtassembly.Assembly$.stratMapping$1(Assembly.scala:47)
[error]         at sbtassembly.Assembly$.inputs$lzycompute$1(Assembly.scala:130)
[error]         at sbtassembly.Assembly$.inputs$1(Assembly.scala:120)
[error]         at sbtassembly.Assembly$.apply(Assembly.scala:147)
[error]         at sbtassembly.Assembly$.$anonfun$assemblyTask$1(Assembly.scala:322)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error]         at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error]         at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error]         at sbt.Execute.work(Execute.scala:291)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[error]         at java.base/java.lang.Thread.run(Thread.java:833)
[error] (assembly) deduplicate: different file contents found in the following:
[error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.4.0/logback-classic-1.4.0.jar:module-info.class
[error] /root/.cache/coursier/v1/https/repo1.maven.org/maven2/ch/qos/logback/logback-core/1.4.0/logback-core-1.4.0.jar:module-info.class
```

`module-info.class` には Java 9 で導入されたモジュールシステムに関する情報が格納されているが、FAT JAR 内で利用する分には[自動モジュール扱い](https://news.mynavi.jp/techplus/article/imajava-5/)で問題がないため、`assemblyMergeStrategy` で破棄する。